### PR TITLE
Fix PS2 CD BIN/CUE packaging

### DIFF
--- a/pop-fe2-ps3.py
+++ b/pop-fe2-ps3.py
@@ -77,6 +77,7 @@ class PopFe2Ps3App:
         self.myrect = None
         self.isos = []
         self.disc_ids = []
+        self.disc_media = []
         self.icon0 = None
         self.icon0_tk = None
         self.pic0 = None
@@ -159,7 +160,8 @@ class PopFe2Ps3App:
         os.mkdir(self.subdir)
 
         self.isos = []
-        self.disc_id = []
+        self.disc_ids = []
+        self.disc_media = []
         self.icon0 = None
         self.icon0_tk = None
         self.pic0 = None
@@ -310,12 +312,22 @@ class PopFe2Ps3App:
         if not len(iso):
             return
 
-        if iso[-4:] == '.chd':
+        package_iso = iso
+        media_type = None
+
+        if iso[-4:].lower() == '.cue':
+            metadata_iso = self.subdir + 'ISO%02d.iso' % len(self.isos)
+            iso, package_iso = popfe2.prepare_cd_image(iso, metadata_iso)
+            temp_files.append(metadata_iso)
+            media_type = 'cd'
+
+        if iso[-4:].lower() == '.chd':
             print('Extracting ISO from CHD.  This is going to take quite a while ...')
             new_path = self.subdir + iso.split(os.sep)[-1][:-4] + '.iso'
             print('Extracting to', new_path)
             subprocess.run(['chdman', 'extractdvd', '-i', iso, '-o', new_path], check=True)
             iso=new_path
+            package_iso = iso
             print('Extracted iso')
             event.widget.configure(path=iso)
             
@@ -333,8 +345,9 @@ class PopFe2Ps3App:
 
             
         if disc == 'd1':
-            self.isos.insert(0, iso)
+            self.isos.insert(0, package_iso)
             self.disc_ids.insert(0, disc_id)
+            self.disc_media.insert(0, media_type)
             self.builder.get_object('disc1', self.master).config(state='disabled')
             self.builder.get_object('disc2', self.master).config(state='normal')
 
@@ -356,22 +369,25 @@ class PopFe2Ps3App:
             self.update_assets()
             
         if disc == 'd2':
-            self.isos.insert(1, iso)
+            self.isos.insert(1, package_iso)
             self.disc_ids.insert(1, disc_id)
+            self.disc_media.insert(1, media_type)
             self.builder.get_object('disc2', self.master).config(state='disabled')
             self.builder.get_object('disc3', self.master).config(state='normal')
             self.builder.get_variable('discid2_variable').set(disc_id)
             self.builder.get_object('discid2', self.master).config(state='normal')
         if disc == 'd3':
-            self.isos.insert(2, iso)
+            self.isos.insert(2, package_iso)
             self.disc_ids.insert(2, disc_id)
+            self.disc_media.insert(2, media_type)
             self.builder.get_object('disc3', self.master).config(state='disabled')
             self.builder.get_object('disc4', self.master).config(state='normal')
             self.builder.get_variable('discid3_variable').set(disc_id)
             self.builder.get_object('discid3', self.master).config(state='normal')
         if disc == 'd4':
-            self.isos.insert(3, iso)
+            self.isos.insert(3, package_iso)
             self.disc_ids.insert(3, disc_id)
+            self.disc_media.insert(3, media_type)
             self.builder.get_object('disc4', self.master).config(state='disabled')
             self.builder.get_variable('discid4_variable').set(disc_id)
             self.builder.get_object('discid4', self.master).config(state='normal')
@@ -591,8 +607,12 @@ class PopFe2Ps3App:
         if pkgdir and len(pkgdir):
             pkgfile = pkgdir + '/' + pkgfile
 
-        popfe2.create_pkg(self.isos, self.disc_ids[0], self.icon0, self.pic0, self.pic1, snd0, pkgfile, self.subdir,
-                          0 if self.builder.get_variable('swap_enabled_variable').get() == 'on' else None)
+        popfe2.create_pkg(
+            self.isos, self.disc_ids[0], self.icon0, self.pic0, self.pic1,
+            snd0, pkgfile, self.subdir,
+            0 if self.builder.get_variable('swap_enabled_variable').get() == 'on' else None,
+            disc_gameids=self.disc_ids, disc_media=self.disc_media
+        )
         self.master.config(cursor='')
 
         d = FinishedDialog(self.master)

--- a/pop-fe2.py
+++ b/pop-fe2.py
@@ -699,7 +699,7 @@ PS2_PLACEHOLDER_KEY = bytes([
 
 verbose = False
 
-def create_limg_sector(filename):
+def create_limg_sector(filename, media_type=None):
     limg = None
     with open(filename, 'r+b') as iso:
         iso.seek(-0x4000, 2)
@@ -713,14 +713,21 @@ def create_limg_sector(filename):
         file_size = iso.tell()
         iso.seek(0)
 
-        if file_size  > 0x2bc00000:
+        if media_type == 'cd':
+            iso.seek(0x9318 + 0x54)
+            buf = iso.read(4);
+            block_size = 0x930  # CD
+            limg_type = 2
+        elif media_type == 'dvd' or file_size > 0x2bc00000:
             iso.seek(0x8000 + 0x54)
             buf = iso.read(4);
             block_size = 0x800  # DVD
+            limg_type = 1
         else:
             iso.seek(0x9318 + 0x54)
             buf = iso.read(4);
             block_size = 0x930  # CD
+            limg_type = 2
 
         num_sectors = struct.unpack_from('>I', buf, 0)[0]
         padding = ((num_sectors) * 2048) % 0x4000
@@ -734,10 +741,7 @@ def create_limg_sector(filename):
         
         limg = bytearray(0x4000)
         limg[:4] = b'LIMG'
-        if file_size  > 0x2bc00000:
-            struct.pack_into('>I', limg, 4, 1)
-        else:
-            struct.pack_into('>I', limg, 4, 2)
+        struct.pack_into('>I', limg, 4, limg_type)
         struct.pack_into('>I', limg, 8, num_sectors)
         struct.pack_into('>I', limg, 12, block_size)
 
@@ -798,6 +802,30 @@ def get_gameid_from_iso(path):
         
     iso.close()
     return None
+
+
+def prepare_cd_image(cue_path, metadata_iso):
+    """Return a cooked metadata ISO and the original raw CD image."""
+    bc = bchunk()
+    bc.open(cue_path)
+    data_tracks = [
+        index for index, track in bc.tracks.items()
+        if track['MODE'] != 'AUDIO'
+    ]
+    if len(data_tracks) != 1 or len(bc.tracks) != 1:
+        raise RuntimeError(
+            'Only single-track PS2 CD BIN+CUE images are supported'
+        )
+
+    data_track = data_tracks[0]
+    track = bc.tracks[data_track]
+    if track['MODE'] not in ['MODE1/2352', 'MODE2/2352']:
+        raise RuntimeError('Unsupported CUE track mode: %s' % track['MODE'])
+
+    # pycdlib needs cooked 2048-byte sectors to inspect ISO9660 metadata.
+    # Keep the original 2352-byte image for PS2 Classics encryption.
+    bc.writetrack(data_track, metadata_iso)
+    return metadata_iso, track['FILE']
 
 
 def get_pic_from_game(pic, gameid, filename):
@@ -1193,7 +1221,9 @@ def create_manual(source, dest, subdir='./pop-fe2-work/'):
     return
         
 
-def create_pkg(isos, gameid, icon0, pic0, pic1, snd0, pkg, subdir='pop-fe2-work', swap=None):
+def create_pkg(isos, gameid, icon0, pic0, pic1, snd0, pkg,
+               subdir='pop-fe2-work', swap=None, disc_gameids=None,
+               disc_media=None):
     cid = 'UP0000-%s_00-PS2CLASSICS00000' % gameid
     #cid = '2P0001-PS2U10000_00-0000111122223333'
     subdir = subdir + '/' + cid
@@ -1309,12 +1339,15 @@ def create_pkg(isos, gameid, icon0, pic0, pic1, snd0, pkg, subdir='pop-fe2-work'
             _c = _c + str(i + 1)
             _ibe = _ibe + str(i + 1)
 
-        print('Get GAMEID from', f)
-        gameid = get_gameid_from_iso(f)
-        print('GAMEID', gameid)
+        if disc_gameids:
+            disc_gameid = disc_gameids[i]
+        else:
+            print('Get GAMEID from', f)
+            disc_gameid = get_gameid_from_iso(f)
+        print('GAMEID', disc_gameid)
 
         # get config
-        config = get_config(gameid, len(isos), i, swap)
+        config = get_config(disc_gameid, len(isos), i, swap)
         #append_title(config, gameid)
         #
         #if len(args.files) > 1:
@@ -1340,7 +1373,8 @@ def create_pkg(isos, gameid, icon0, pic0, pic1, snd0, pkg, subdir='pop-fe2-work'
         shutil.copyfile(f, subdir + '/USRDIR/game.iso')
 
         # Create a LIMG sector if we need one
-        create_limg_sector(subdir + '/USRDIR/game.iso')
+        media_type = disc_media[i] if disc_media else None
+        create_limg_sector(subdir + '/USRDIR/game.iso', media_type)
 
         print('Creating ISO.BIN.ENC')
         ps2classic.encrypt_image('cex', 'klic.bin',
@@ -1404,17 +1438,25 @@ if __name__ == "__main__":
         print('No ART directory found. Download and install \'https://archive.org/details/ps2-opl-cover-art-set\' in the same directory as pop-fe2.py')
         os._exit(0)
 
+    package_files = list(args.files)
+    package_media = [None] * len(args.files)
+    asset_base = os.path.splitext(args.files[0])[0]
     for i, f in enumerate(args.files):
         if f[-4:].lower() == '.cue':
-            bc = bchunk()
-            bc.open(f)
-            bc.writetrack(1, 'pop-fe2-work/ISO%02d.iso' & i)
-            args.files[i] = 'pop-fe2-work/ISO%02d.iso & i'
+            metadata_iso = 'pop-fe2-work/ISO%02d.iso' % i
+            metadata_iso, package_file = prepare_cd_image(f, metadata_iso)
+            args.files[i] = metadata_iso
+            package_files[i] = package_file
+            package_media[i] = 'cd'
 
-    gameid = get_gameid_from_iso(args.files[0])
-    if not gameid:
-        print('Could not identify the game')
-        os._exit(1)
+    disc_gameids = []
+    for metadata_file in args.files:
+        disc_gameid = get_gameid_from_iso(metadata_file)
+        if not disc_gameid:
+            print('Could not identify the game')
+            os._exit(1)
+        disc_gameids.append(disc_gameid)
+    gameid = disc_gameids[0]
     print('GAMEID:', gameid)
     print('TITLE:', games[gameid]['title'])
 
@@ -1423,11 +1465,11 @@ if __name__ == "__main__":
     if args.ps3_pkg == 'gameid':
         args.ps3_pkg = gameid + '.pkg'
 
-    pic0 = get_pic_from_game('pic0', gameid, args.files[0][:-4] + '_pic0.png')
+    pic0 = get_pic_from_game('pic0', gameid, asset_base + '_pic0.png')
 
-    pic1 = get_pic_from_game('pic1', gameid, args.files[0][:-4] + '_pic1.png')
+    pic1 = get_pic_from_game('pic1', gameid, asset_base + '_pic1.png')
 
-    icon0 = get_pic_from_game('icon0', gameid, args.files[0][:-4] + '_icon0.png')
+    icon0 = get_pic_from_game('icon0', gameid, asset_base + '_icon0.png')
 
     
     snd0 = args.snd0
@@ -1436,8 +1478,8 @@ if __name__ == "__main__":
         print('Skipping SND0')
     else:
         try:
-            os.stat(args.files[0][:-4] + '.snd0')
-            snd0 = args.files[0][:-4] + '.snd0'
+            os.stat(asset_base + '.snd0')
+            snd0 = asset_base + '.snd0'
         except:
             True
         if not snd0 and 'snd0' in games[gameid]:
@@ -1451,4 +1493,6 @@ if __name__ == "__main__":
     except:
         s = None
 
-    create_pkg(args.files, gameid, icon0, pic0, pic1, snd0, args.ps3_pkg, subdir, swap=s)
+    create_pkg(package_files, gameid, icon0, pic0, pic1, snd0,
+               args.ps3_pkg, subdir, swap=s, disc_gameids=disc_gameids,
+               disc_media=package_media)


### PR DESCRIPTION
Fixes #16.

## What changed

- Extract a temporary cooked 2048-byte ISO from single-track MODE1/2352 or MODE2/2352 CUE images for ISO9660 metadata and game-ID detection.
- Keep the original raw 2352-byte BIN as the input to PS2 Classics encryption.
- Pass the already detected per-disc game IDs and media types into `create_pkg` instead of trying to parse the raw BIN with `pycdlib` again.
- Create an explicit CD LIMG header with type `2` and block size `0x930`.
- Fix the two broken CUE output-path formatting expressions.
- Apply the same workflow in both the CLI and PS3 GUI paths while preserving the recently added CHD DVD handling.

## Root cause

PS2 CD dumps use raw 2352-byte sectors, which `pycdlib` cannot parse directly. Converting the image to a cooked 2048-byte ISO is useful for reading `SYSTEM.CNF`, but using that cooked ISO for the final package loses the original CD sector layout.

## Validation

- `python3 -m py_compile pop-fe2.py pop-fe2-ps3.py`
- Tested with `4x4 Evo (Europe) (En,Fr,De)`, a single-track Redump MODE2/2352 BIN/CUE image.
- Detected game ID: `SLES50194`.
- Generated CD LIMG header: `4c494d470000000200039d2900000930`.
- Built the final PKG directly from the raw BIN/CUE and confirmed it boots and runs on real PS3 hardware.

The current upstream CUE path fails before conversion because it applies `& i` to a string, and a cooked-ISO workaround produces an invalid zero-sector LIMG header for this image.
